### PR TITLE
[#8] 댓글에 대한 추가,삭제 기능 추가

### DIFF
--- a/app/api/comment/route.ts
+++ b/app/api/comment/route.ts
@@ -2,7 +2,7 @@ import { NextRequest } from 'next/server';
 import prisma from '../../../prisma/client';
 import { cookies } from 'next/headers';
 import { verifyToken } from '../../lib/token';
-import { createCommentByDiaryId } from '../../lib/comment';
+import { createCommentByDiaryId, deleteCommentById } from '../../lib/comment';
 
 export async function POST(req: NextRequest) {
   const { diaryId, comment } = await req.json();
@@ -44,5 +44,42 @@ export async function POST(req: NextRequest) {
         status: 502,
       }
     );
+  }
+}
+
+export async function DELETE(req: NextRequest) {
+  const { commentId } = await req.json();
+  try {
+    const userId = verifyToken(
+      cookies().get('dreaming_accessToken')?.value ?? ''
+    ).userId;
+  } catch (e) {
+    return new Response(
+      JSON.stringify({
+        error: '토큰이 만료되었습니다.',
+      }),
+      {
+        status: 401,
+      }
+    );
+  }
+
+  try {
+    const userId = verifyToken(
+      cookies().get('dreaming_accessToken')?.value ?? ''
+    ).userId;
+
+    await deleteCommentById(commentId, userId);
+    return new Response(
+      JSON.stringify({ data: '성공적으로 댓글을 삭제했어요' }),
+      {
+        status: 200,
+      }
+    );
+  } catch (e) {
+    return new Response(JSON.stringify(e), {
+      status: 502,
+      statusText: '댓글을 삭제할 수 없어요!',
+    });
   }
 }

--- a/app/api/comment/route.ts
+++ b/app/api/comment/route.ts
@@ -1,0 +1,48 @@
+import { NextRequest } from 'next/server';
+import prisma from '../../../prisma/client';
+import { cookies } from 'next/headers';
+import { verifyToken } from '../../lib/token';
+import { createCommentByDiaryId } from '../../lib/comment';
+
+export async function POST(req: NextRequest) {
+  const { diaryId, comment } = await req.json();
+  try {
+    const userId = verifyToken(
+      cookies().get('dreaming_accessToken')?.value ?? ''
+    ).userId;
+  } catch (e) {
+    return new Response(
+      JSON.stringify({
+        error: '토큰이 만료되었습니다.',
+      }),
+      {
+        status: 401,
+      }
+    );
+  }
+
+  try {
+    const userId = verifyToken(
+      cookies().get('dreaming_accessToken')?.value ?? ''
+    ).userId;
+    const newComment = await createCommentByDiaryId({
+      diaryId,
+      writerId: userId,
+      comment,
+    });
+
+    return new Response(JSON.stringify(newComment), {
+      status: 200,
+      statusText: '댓글이 작성되었습니다!',
+    });
+  } catch (e) {
+    return new Response(
+      JSON.stringify({
+        error: e,
+      }),
+      {
+        status: 502,
+      }
+    );
+  }
+}

--- a/app/api/comment/route.ts
+++ b/app/api/comment/route.ts
@@ -27,7 +27,7 @@ export async function POST(req: NextRequest) {
     ).userId;
     const newComment = await createCommentByDiaryId({
       diaryId,
-      writerId: userId,
+      writerId: userId + '',
       comment,
     });
 

--- a/app/api/diary/[id]/route.ts
+++ b/app/api/diary/[id]/route.ts
@@ -13,11 +13,11 @@ import { cookies } from 'next/headers';
 export async function GET(req: NextRequest) {
   const urlArray = new URL(req.url).pathname.split('/');
   const id = urlArray[urlArray.length - 1];
-  const userId = verifyToken(
-    cookies().get('dreaming_accessToken')?.value ?? ''
-  ).userId;
-
-  if (!userId) {
+  try{
+    const userId = verifyToken(
+      cookies().get('dreaming_accessToken')?.value ?? ''
+    ).userId;
+  }catch(e){
     return new Response(
       JSON.stringify({
         error: '토큰이 만료되었습니다.',
@@ -51,11 +51,11 @@ export async function GET(req: NextRequest) {
   }
 }
 export async function DELETE(req: NextRequest) {
-  const userId = verifyToken(
-    cookies().get('dreaming_accessToken')?.value ?? ''
-  ).userId;
-
-  if (!userId) {
+  try{
+    const userId = verifyToken(
+      cookies().get('dreaming_accessToken')?.value ?? ''
+    ).userId;
+  }catch(e){
     return new Response(
       JSON.stringify({
         error: '토큰이 만료되었습니다.',
@@ -84,12 +84,12 @@ export async function DELETE(req: NextRequest) {
   }
 }
 
-export async function PATCH(req: NextRequest) {
-  const userId = verifyToken(
-    cookies().get('dreaming_accessToken')?.value ?? ''
-  ).userId;
-
-  if (!userId) {
+export async function PATCH(req: NextRequest) {  
+  try{
+    const userId = verifyToken(
+      cookies().get('dreaming_accessToken')?.value ?? ''
+    ).userId;
+  }catch(e){
     return new Response(
       JSON.stringify({
         error: '토큰이 만료되었습니다.',
@@ -147,7 +147,7 @@ export async function PATCH(req: NextRequest) {
       },
     ]);
 
-    return new NextResponse(JSON.stringify(updatedDiary), {
+    return new Response(JSON.stringify(updatedDiary), {
       status: 200,
     });
   } catch (e) {

--- a/app/api/diary/route.ts
+++ b/app/api/diary/route.ts
@@ -6,11 +6,12 @@ import { createNewDiary, getAllDiaryByUser } from '../../lib/diary';
 import { cookies } from 'next/headers';
 
 export async function GET(req: NextRequest) {
-  const userId = verifyToken(
-    cookies().get('dreaming_accessToken')?.value ?? ''
-  ).userId;
-
-  if (!userId) {
+  try {
+    const userId = verifyToken(
+      cookies().get('dreaming_accessToken')?.value ?? ''
+    ).userId;
+  } catch (e) {
+    console.log(e);
     return new Response(
       JSON.stringify({
         error: '토큰이 만료되었습니다.',
@@ -22,6 +23,9 @@ export async function GET(req: NextRequest) {
   }
 
   try {
+    const userId = verifyToken(
+      cookies().get('dreaming_accessToken')?.value ?? ''
+    ).userId;
     const getAllPosts = await getAllDiaryByUser(userId);
 
     if (userId && getAllPosts) {

--- a/app/api/diary/route.ts
+++ b/app/api/diary/route.ts
@@ -6,6 +6,8 @@ import { createNewDiary, getAllDiaryByUser } from '../../lib/diary';
 import { cookies } from 'next/headers';
 
 export async function GET(req: NextRequest) {
+  const page = req.nextUrl.searchParams.get('page');
+  const pageSize = req.nextUrl.searchParams.get('pageSize');
   try {
     const userId = verifyToken(
       cookies().get('dreaming_accessToken')?.value ?? ''
@@ -26,7 +28,11 @@ export async function GET(req: NextRequest) {
     const userId = verifyToken(
       cookies().get('dreaming_accessToken')?.value ?? ''
     ).userId;
-    const getAllPosts = await getAllDiaryByUser(userId);
+    const getAllPosts = await getAllDiaryByUser(
+      userId,
+      parseInt(page as string),
+      parseInt(pageSize as string)
+    );
 
     if (userId && getAllPosts) {
       return new Response(JSON.stringify(getAllPosts), {

--- a/app/api/user/route.ts
+++ b/app/api/user/route.ts
@@ -1,0 +1,41 @@
+import { NextRequest } from 'next/server';
+
+import { cookies } from 'next/headers';
+import { verifyToken } from '../../lib/token';
+import { getUserByUserId } from '../../lib/user';
+
+export async function GET(req: NextRequest) {
+  const userId = verifyToken(
+    cookies().get('dreaming_accessToken')?.value ?? ''
+  ).userId;
+
+  if (!userId) {
+    return new Response(
+      JSON.stringify({
+        error: '유효하지 않은 사용자입니다.',
+      }),
+      {
+        status: 401,
+      }
+    );
+  }
+  const user = await getUserByUserId(userId + '');
+  if (user) {
+    return new Response(
+      JSON.stringify({
+        user,
+      }),
+      {
+        status: 200,
+      }
+    );
+  }
+  return new Response(
+    JSON.stringify({
+      error: '사용자를 찾을 수 없습니다.',
+    }),
+    {
+      status: 404,
+    }
+  );
+}

--- a/app/api/user/route.ts
+++ b/app/api/user/route.ts
@@ -5,20 +5,23 @@ import { verifyToken } from '../../lib/token';
 import { getUserByUserId } from '../../lib/user';
 
 export async function GET(req: NextRequest) {
-  const userId = verifyToken(
-    cookies().get('dreaming_accessToken')?.value ?? ''
-  ).userId;
-
-  if (!userId) {
+  try {
+    const userId = verifyToken(
+      cookies().get('dreaming_accessToken')?.value ?? ''
+    ).userId;
+  } catch (e) {
     return new Response(
       JSON.stringify({
-        error: '유효하지 않은 사용자입니다.',
+        error: '토큰이 만료되었습니다.',
       }),
       {
         status: 401,
       }
     );
   }
+  const userId = verifyToken(
+    cookies().get('dreaming_accessToken')?.value ?? ''
+  ).userId;
   const user = await getUserByUserId(userId + '');
   if (user) {
     return new Response(

--- a/app/auth/signIn/page.tsx
+++ b/app/auth/signIn/page.tsx
@@ -1,4 +1,5 @@
 'use client';
+
 import { useEffect } from 'react';
 import { KakaoLoginButton } from '../../components/Kakao/Login';
 import { KakaoLogout } from '../../components/Kakao/Logout';
@@ -6,13 +7,16 @@ import { KakaoLogout } from '../../components/Kakao/Logout';
 const SignIn = () => {
   useEffect(() => {
     const createNewPost = async () => {
-      await fetch(`/api/diary`, {
-        method: 'GET',
+      await fetch(`/api/comment`, {
+        method: 'POST',
         headers: {
           'Content-Type': 'application/json',
         },
+        body: JSON.stringify({
+          comment: '안녕하세요',
+          diaryId: 'cluhv6y4r00011387hiqqex76',
+        }),
       });
-      console.log(createNewPost);
     };
 
     createNewPost();

--- a/app/lib/comment.ts
+++ b/app/lib/comment.ts
@@ -28,8 +28,7 @@ const createCommentByDiaryId = async ({
     await prisma.comment.create({
       data: {
         diaryId,
-        writerId,
-        parentId: '',
+        writerId: writerId + '',
         contents: comment,
         created_At: toKoreanTimeStamp(new Date()),
         updated_At: toKoreanTimeStamp(new Date()),

--- a/app/lib/comment.ts
+++ b/app/lib/comment.ts
@@ -29,7 +29,7 @@ const createCommentByDiaryId = async ({
       data: {
         diaryId,
         writerId: writerId + '',
-        contents: comment,
+        comment,
         created_At: toKoreanTimeStamp(new Date()),
         updated_At: toKoreanTimeStamp(new Date()),
       },
@@ -84,7 +84,7 @@ const patchCommentByCommentId = async ({
       },
       data: {
         ...getComment,
-        contents: comment,
+        comment,
         updated_At: toKoreanTimeStamp(new Date()),
       },
     });

--- a/app/lib/comment.ts
+++ b/app/lib/comment.ts
@@ -39,22 +39,26 @@ const createCommentByDiaryId = async ({
   }
 };
 
-const deleteCommentById = async (commentId: string) => {
+const deleteCommentById = async (commentId: string, userId: string) => {
   try {
+    //댓글 작성자가 현재 로그인 한 유저와 동일하다면
     //해당 댓글을 부모로 갖는 모든 자식 댓글들
+
     const childComments = await prisma.comment.findMany({
       where: {
         parentId: commentId,
+        writerId: userId + '',
       },
     });
 
     childComments.forEach(async (comment) => {
-      await deleteCommentById(comment.id);
+      await deleteCommentById(comment.id, userId + '');
     });
 
     await prisma.comment.delete({
       where: {
         id: commentId,
+        writerId: userId + '',
       },
     });
   } catch (e) {

--- a/app/lib/diary.ts
+++ b/app/lib/diary.ts
@@ -52,12 +52,18 @@ const getDiaryById = async (diaryId: string) => {
   }
 };
 
-const getAllDiaryByUser = async (userId: string) => {
+const getAllDiaryByUser = async (
+  userId: string,
+  skip: number,
+  take: number
+) => {
   try {
     const allDiary = await prisma.diary.findMany({
       where: {
         writerId: userId + '',
       },
+      skip,
+      take,
     });
     return allDiary;
   } catch (e) {

--- a/app/lib/diary.ts
+++ b/app/lib/diary.ts
@@ -11,14 +11,12 @@ const createNewDiary = async ({
   isShare,
   writer,
   like,
-  comments,
 }: {
   writer: Number;
   title: string;
   content: string;
   isShare: boolean;
   like?: number;
-  comments?: Comment[];
 }) => {
   try {
     const newDiary = await prisma.diary.create({
@@ -27,6 +25,9 @@ const createNewDiary = async ({
         isShare,
         title: title,
         contents: content,
+        comments: {
+          create: [],
+        },
         created_At: toKoreanTimeStamp(new Date()),
         updated_At: toKoreanTimeStamp(new Date()),
         like: 0,
@@ -44,7 +45,11 @@ const getDiaryById = async (diaryId: string) => {
       where: {
         id: diaryId,
       },
+      include: {
+        comments: true,
+      },
     });
+    console.log(diary);
 
     return diary;
   } catch (e) {
@@ -88,7 +93,7 @@ const patchDiaryById = async (
   diaryId: string,
   args: Parameters<typeof createNewDiary>
 ) => {
-  const { title, content, like, comments, isShare } = args[0];
+  const { title, content, like, isShare } = args[0];
   try {
     await prisma.diary.update({
       where: {

--- a/app/lib/user.ts
+++ b/app/lib/user.ts
@@ -8,6 +8,24 @@ interface createNewUserParms {
   refreshToken: string;
 }
 
+const getUserByUserId = async (userId: string) => {
+  try {
+    return await prisma.member.findUnique({
+      where: {
+        id: userId,
+      },
+      select: {
+        id:true,
+        name:true,
+        point:true,
+        picture:true,
+      },
+    });
+  } catch (e) {
+    console.error(e);
+  }
+};
+
 const createNewUser = async ({
   id,
   name,
@@ -45,4 +63,4 @@ const createNewUser = async ({
   return newUniqueUser;
 };
 
-export { createNewUser };
+export { createNewUser, getUserByUserId };

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -47,7 +47,7 @@ model Comment {
   parentId String?
   //마찬가지
   children Comment[] @relation("ParentChild")
-  diary    Diary    @relation(fields: [diaryId], references: [id], map: "CommentDiary_FK")
+  diary    Diary    @relation(fields: [diaryId], references: [id], map: "CommentDiary_FK" ,onDelete: Cascade)
   diaryId  String
   created_At String?
   updated_At String?

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -15,7 +15,7 @@ model Member {
   picture  String?
   nickname String?
   point    Int      @default(0)
-  comments Comment[]
+  comments Comment[] 
   diary Diary[]
   refreshToken String?  @unique 
 }
@@ -38,7 +38,7 @@ model Diary {
 model Comment {
   //기본키
   id       String   @id @default(cuid())
-  contents String
+  comment String?
   //Member의 ID를 writerID로서 참조한다.(외래 키)
   writer   Member   @relation(fields: [writerId], references: [id])
   writerId String


### PR DESCRIPTION
## - 목적
관련 이슈: #8 
-

<br>

## - 주요 변경 사항

- 댓글에 대한 추가 연산을 구현하였습니다.
- 댓글에 대한 삭제 연산을 구현하였습니다.
- 추가로 `모든 꿈 조회`에 대해 요청하려면 `api/diary?page=1&pageSize=5`요 주소로 `GET요청`을 보내면 됩니다!

## 기타 사항 (선택)

-

<br>

## - 스크린샷 (선택)
