### PR TITLE
[#11] 다이어리 검색 기능

### DIFF
--- a/app/api/diaries/route.ts
+++ b/app/api/diaries/route.ts
@@ -22,6 +22,7 @@ export async function GET(req: NextRequest) {
       searchKeyword ?? '',
       (Number(page) - 1) * 15
     );
+    console.log(allKeywords);
     if (allKeywords.length === 0) {
       return new Response(
         JSON.stringify({
@@ -37,7 +38,7 @@ export async function GET(req: NextRequest) {
     });
   } catch (e) {
     return new Response(JSON.stringify(e), {
-      status: 502,
+      status: 500,
     });
   }
 }

--- a/app/api/diaries/route.ts
+++ b/app/api/diaries/route.ts
@@ -1,0 +1,43 @@
+import { NextRequest } from 'next/server';
+import { isLengthInRange } from '../../../utils';
+
+import { getDiariesBySearchKeyword } from '../../lib/diaries';
+export async function GET(req: NextRequest) {
+  const searchKeyword = req.nextUrl.searchParams.get('search');
+  const page = req.nextUrl.searchParams.get('page');
+
+  if (searchKeyword && !isLengthInRange(searchKeyword, 0, 500)) {
+    return new Response(
+      JSON.stringify({
+        error: '다이어리 검색은 최대 500자까지 가능합니다',
+      }),
+      {
+        status: 502,
+      }
+    );
+  }
+
+  try {
+    const allKeywords = await getDiariesBySearchKeyword(
+      searchKeyword ?? '',
+      (Number(page) - 1) * 15
+    );
+    if (allKeywords.length === 0) {
+      return new Response(
+        JSON.stringify({
+          data: '찾는 다이어리가 존재하지 않아요!',
+        }),
+        {
+          status: 404,
+        }
+      );
+    }
+    return new Response(JSON.stringify(allKeywords), {
+      status: 200,
+    });
+  } catch (e) {
+    return new Response(JSON.stringify(e), {
+      status: 502,
+    });
+  }
+}

--- a/app/api/diary/route.ts
+++ b/app/api/diary/route.ts
@@ -4,6 +4,7 @@ import { DIARY } from '../../../constants';
 import { isLengthInRange } from '../../../utils';
 import { createNewDiary, getAllDiaryByUser } from '../../lib/diary';
 import { cookies } from 'next/headers';
+import { addUserPoints } from '../../lib/point';
 
 export async function GET(req: NextRequest) {
   const page = req.nextUrl.searchParams.get('page');
@@ -107,6 +108,8 @@ export async function POST(req: NextRequest) {
       isShare,
       writer: Number(decodedToken?.userId),
     });
+
+    await addUserPoints(userId + '');
     return new Response(JSON.stringify(newPost), {
       status: 200,
     });

--- a/app/api/diary/route.ts
+++ b/app/api/diary/route.ts
@@ -8,6 +8,7 @@ import { cookies } from 'next/headers';
 export async function GET(req: NextRequest) {
   const page = req.nextUrl.searchParams.get('page');
   const pageSize = req.nextUrl.searchParams.get('pageSize');
+  const skip = (Number(page) - 1) * Number(pageSize);
   try {
     const userId = verifyToken(
       cookies().get('dreaming_accessToken')?.value ?? ''
@@ -30,7 +31,7 @@ export async function GET(req: NextRequest) {
     ).userId;
     const getAllPosts = await getAllDiaryByUser(
       userId,
-      parseInt(page as string),
+      parseInt(skip + ''),
       parseInt(pageSize as string)
     );
 

--- a/app/lib/diaries.ts
+++ b/app/lib/diaries.ts
@@ -1,0 +1,30 @@
+import prisma from '../../prisma/client';
+
+const getDiariesBySearchKeyword = async (keyword: string, page: number) => {
+  try {
+    console.log(keyword, page);
+    const getDiariesFromKeyword = await prisma.diary.findMany({
+      where: {
+        isShare: true,
+        OR: [
+          {
+            title: {
+              contains: keyword,
+            },
+            contents: {
+              contains: keyword,
+            },
+          },
+        ],
+      },
+      skip: page,
+      take: 15,
+    });
+    console.log(getDiariesBySearchKeyword);
+    return getDiariesFromKeyword;
+  } catch (e) {
+    throw e;
+  }
+};
+
+export { getDiariesBySearchKeyword };

--- a/app/lib/diaries.ts
+++ b/app/lib/diaries.ts
@@ -2,7 +2,6 @@ import prisma from '../../prisma/client';
 
 const getDiariesBySearchKeyword = async (keyword: string, page: number) => {
   try {
-    console.log(keyword, page);
     const getDiariesFromKeyword = await prisma.diary.findMany({
       where: {
         isShare: true,
@@ -20,7 +19,6 @@ const getDiariesBySearchKeyword = async (keyword: string, page: number) => {
       skip: page,
       take: 15,
     });
-    console.log(getDiariesBySearchKeyword);
     return getDiariesFromKeyword;
   } catch (e) {
     throw e;

--- a/app/lib/point.ts
+++ b/app/lib/point.ts
@@ -1,0 +1,30 @@
+import prisma from '../../prisma/client';
+
+const addUserPoints = async (userId: string) => {
+  const user = await prisma.member.findUnique({
+    where: {
+      id: userId,
+    },
+  });
+
+  if (!user) {
+    throw new Error('사용자를 찾을 수 없습니다.');
+  }
+
+  try {
+    const updatedUser = await prisma.member.update({
+      where: {
+        id: userId,
+      },
+      data: {
+        point: user.point + 100,
+      },
+    });
+
+    return updatedUser;
+  } catch (error) {
+    throw new Error('포인트를 갱신할 수 없습니다');
+  }
+};
+
+export { addUserPoints };

--- a/package-lock.json
+++ b/package-lock.json
@@ -2167,11 +2167,10 @@
         "node": ">=16"
       }
     },
-
     "node_modules/convert-source-map": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
-     "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A=="
+      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A=="
     },
     "node_modules/cookie": {
       "version": "0.5.0",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,10 +1,12 @@
 generator client {
   provider = "prisma-client-js"
+  previewFeatures = ["fullTextIndex"]
 }
 
 datasource db {
   provider = "mysql"
   url      = env("DATABASE_URL")
+  
 }
 
 model Member {
@@ -32,6 +34,8 @@ model Diary {
   isShare  Boolean   @default(true)
   created_At String?
   updated_At String?
+  
+  @@fulltext([title,contents])
 }
 
 //댓글 모델


### PR DESCRIPTION
## - 목적
관련 이슈: #11 

https://chain-yak-e56.notion.site/6d0743bfc5064f96b976deb607fe727b?pvs=4

- 다이어리 커뮤니티에서 쓰이는 검색 기능을 추가했습니다.
- 다이어리 리스트 검색과 마찬가지로 무한스크롤 형태로 요청을 보내야 합니다.
- `search?새 포스트&page=1`쿼리 스트링으로 검색을 합니다.
- `게시글,제목`에 대해 인덱싱을 추가했습니다.

<br>

## - 주요 변경 사항


-

## 기타 사항 (선택)

-

<br>

## - 스크린샷 (선택)
