### PR TITLE
[#32] 꿈 사전 검색 API 추가

### DIFF
--- a/app/api/dictionary/search/route.ts
+++ b/app/api/dictionary/search/route.ts
@@ -1,0 +1,29 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getDictionaryFromSearch } from '../../../lib/dictionary';
+
+export async function GET(req: NextRequest) {
+  const keyword = req.nextUrl.searchParams.get('keyword');
+
+  try {
+    const getAllDictionaries = await getDictionaryFromSearch(keyword ?? '');
+
+    return new Response(
+      JSON.stringify({
+        dictionaries: getAllDictionaries,
+      }),
+      {
+        status: 200,
+      }
+    );
+  } catch (e) {
+    console.error(e);
+    return NextResponse.json(
+      {
+        error: e,
+      },
+      {
+        status: 502,
+      }
+    );
+  }
+}

--- a/app/lib/dictionary.ts
+++ b/app/lib/dictionary.ts
@@ -125,9 +125,34 @@ const createDreamingContent = async (category: string) => {
   }
 };
 
+const getDictionaryFromSearch = async (searchInput: string) => {
+  try {
+    const getDiariesFromKeyword = await prisma.dictionary.findMany({
+      where: {
+        OR: [
+          {
+            title: {
+              contains: searchInput,
+            },
+            contents: {
+              contains: searchInput,
+            },
+          },
+        ],
+      },
+    });
+
+    return getDiariesFromKeyword;
+  } catch (e) {
+    console.error(e);
+    throw e;
+  }
+};
+
 export {
   getDreamingContentsByCategory,
   getDreamingKeywordByCategory,
   createDreamingContent,
   getDreamingDictionary,
+  getDictionaryFromSearch,
 };

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -64,4 +64,5 @@ model Dictionary {
   title    String
   contents String 
   @@index([category])
+  @@fulltext([title,contents])
 }


### PR DESCRIPTION
## - 목적
관련 이슈: #32 
- 꿈 사전 검색 API를 개발했습니다.
- `/api/dictionary/search?keyword=효키키꿈`이런식으로 `keyword`를 쿼리 스트링으로 넘겨야 합니다.
- 각 검색어에 맞는 응답이 내려갑니다.
- 응답은 `dictionaries`에 담겨서 옵니다. 아래 자세한 예시가 있어요!

```json
{
  "dictionaries": [
    {
      "id": "clup9uaqa0042cegvjinolpx4",
      "category": "자연",
      "title": "지진이 일어나거나 땅이 몹시 흔들리는 꿈",
      "contents": "지진이 일어나거나 땅이 몹시 흔들리는 꿈을 꾸게되면 큰 규모의 총파업, 분규, 혁명이 발발한다. 작게는 개인적인 변동이 있거나 사소한 일로 소송사건에 휘말린다."
    },
    {
      "id": "clupbpxvw0153h4l47md0fnxc",
      "category": "장소",
      "title": "지진나서 건물이 무너지는 꿈",
      "contents": "지진나서 건물이 무너지는 꿈은 약간 재미있습니다. 건물이 애매하게 무너지는 경우에는 흉몽이지만 완전히 폭삭 무너지는 경우에는 길몽입니다. 폭삭 무너지는 경우에는 새로운 기회 새로운 출발을 의미하는 것이지만, 애매하게 무너지는 경우에는 수리를 할 수 밖에 없기 때문인것 같습니다."
    },
    {
      "id": "cluqhulp200dpluvfvxrhjycc",
      "category": "기타",
      "title": "지진이 일어나 정원수나 수목이 쓰러지는 꿈",
      "contents": "지진이 일어나 정원수나 수목이 쓰러지는 꿈을 꾸게되면 자신의 신상에 중대한 장애나 곤경, 불행한 일이 일어남을 예시하는 꿈이다."
    },
    {
      "id": "cluqhulp200drluvfnll94rxj",
      "category": "기타",
      "title": "지진이 일어나거나 땅이 몹시 흔들리는 꿈",
      "contents": "지진이 일어나거나 땅이 몹시 흔들리는 꿈을 꾸게되면 큰 규모의 총파업, 분규, 혁명이 발발한다. 작게는 개인적인 변동이 있거나 사소한 일로 소송사건에 휘말린다."
    }
  ]
}
```

<br>

## - 주요 변경 사항

-

## 기타 사항 (선택)

-

<br>

## - 스크린샷 (선택)
